### PR TITLE
Fix label overlapping in table when filter has an icon

### DIFF
--- a/projects/centeva-core/src/components/table/table.component.scss
+++ b/projects/centeva-core/src/components/table/table.component.scss
@@ -168,3 +168,13 @@
     margin: 0 30px;
   }
 }
+
+// Fix some Material form field bugs with label max width and icon prefix/suffix
+// If Material fixes these can be removed
+::ng-deep .mat-mdc-form-field-has-icon-suffix .mdc-floating-label:not(.mdc-floating-label--float-above) {
+  max-width: calc(158px);
+}
+
+::ng-deep .mat-mdc-form-field-has-icon-prefix .mdc-floating-label:not(.mdc-floating-label--float-above) {
+  max-width: calc(158px);
+}


### PR DESCRIPTION
This is a bug (or oversight) in the Angular Material library that is used for the UI components at the top of this Search table.  As such, a final fix is in the hands of its maintainers.  We can remove these changes when the bug is addressed.

The bug happens when a form field uses the “outlined” style, contains either a prefix or suffix icon, and has a label displayed inside the field when not in focus.  The label is correctly positioned to the right or left of the icon, but the maximum width is not altered accordingly so that the label is truncated before overlapping that icon.