### PR TITLE
chore: pin Node 24.15.0 via Volta

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
   },
   "author": "",
   "license": "ISC",
-  "homepage": "https://github.com/Centeva/Centeva-Angular"
+  "homepage": "https://github.com/Centeva/Centeva-Angular",
+  "volta": {
+    "node": "24.15.0"
+  }
 }


### PR DESCRIPTION
## Description

This PR adds a Volta node pin to `package.json` so all Volta users on the team automatically use the correct Node version (>=20.19 required by Angular CLI 21) without having to pin manually each session.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Tests
- [x] 🤖 Build/CI
- [x] 📦 Chore (Version bump, release, etc.)
- [ ] ⏩ Revert

## Related Tickets & Documents

N/A

## Changes Made

- Added `"volta": { "node": "24.15.0" }` to root `package.json`. Any developer using Volta will now automatically have Node 24.15.0 activated when working in this repo, satisfying the Angular CLI 21 minimum requirement of Node >=20.19.

## Screenshots (if applicable)

N/A

## Quality Checklist

- [ ] I have added or updated automated tests as needed.
- [x] I have reviewed the code changes myself.
- [x] I have used commit messages that adequately explain my changes.
- [x] I have removed any extra logging, debugging code, and commented out code.
- [ ] I have updated any related documentation (if necessary).

## Additional Notes

This was intentionally kept as a separate PR from the `HeaderTemplate` feature so the team can discuss and approve the Volta toolchain change independently. Developers not using Volta are unaffected — the `"volta"` field is ignored by npm and Node directly.